### PR TITLE
fix for window.resize when vtree not visible

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -122,7 +122,7 @@ init_js <- function(init_event, onwindow_resize, shortcuts) {
   initjs <- sprintf(initjs, init_event)
 
   resize <- '$(window).on("resize", function(){
-      if ($(".grViz svg").length > 0) {
+      if ($(".grViz svg:visible").length > 0) {
         var inst = svgPanZoom(".grViz svg");
         inst.resize(); // update SVG cached size and controls positions
         inst.fit();


### PR DESCRIPTION
If the vtree is on a Shiny-tabpanel, that is currently not visible, the following error will occur in the browser console.
The vtree has to be intialized first.

`# Uncaught DOMException: An attempt was made to use an object that is not, or is no longer, usable`

By changing the jquery selector, this should be fixed.